### PR TITLE
fix: script setup check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { transform } from '.'
 export * from './core/transform'
 export * from './types'
 
-const scriptSetupRE = /<script\s+setup/
+const scriptSetupRE = /<script\s(.*\s)?setup(\s.*)?>/
 
 export default createUnplugin<ScriptSetupTransformOptions>(options => ({
   name: 'unplugin-vue2-script-setup',


### PR DESCRIPTION
improve sfc script setup check
```
<script setup> //✅
<script a="b"  setup lang="ts"> // ✅
<script lang="ts" setup> // ✅
<script lang="setup"> // ⛔️
<script setupa> // ⛔️
```