### PR TITLE
doc : add guide volar vue 2 template setup (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ If the global types are missing for your IDE, update your `tsconfig.json` with:
 
 ###### Support Vue 2 template
 
-Volar preferentially supports Vue 3. Vue 3 and Vue 2 template has some different. You need to set the experimentalCompatMode option to support Vue 2 template.
+Volar preferentially supports Vue 3. Vue 3 and Vue 2 template has some different. You need to set the `experimentalCompatMode` option to support Vue 2 template.
 
 ```jsonc
 {

--- a/README.md
+++ b/README.md
@@ -244,6 +244,21 @@ If the global types are missing for your IDE, update your `tsconfig.json` with:
 }
 ```
 
+###### Support Vue 2 template
+
+Volar preferentially supports Vue 3. Vue 3 and Vue 2 template has some different. You need to set the experimentalCompatMode option to support Vue 2 template.
+
+```jsonc
+{
+  "compilerOptions": {
+    ...
+  },
+  "vueCompilerOptions": {
+    "experimentalCompatMode": 2
+  },
+}
+```
+
 ###### ESLint
 
 If you are using ESLint, you might get `@typescript-eslint/no-unused-vars` warning with `<script setup>`. You can disable it and add `noUnusedLocals: true` in your `tsconfig.json`, Volar will infer the real missing locals correctly for you. 


### PR DESCRIPTION
Add guide setup Volar accept Vue 2 template type checking.