### PR TITLE
feat: support defineExpose

### DIFF
--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -215,6 +215,29 @@ export default __sfc_main;
 "
 `;
 
+exports[`transform fixtures test/fixtures/MacrosDefineExpose.vue 1`] = `
+"<template>
+  <div>{{a}}</div>
+</template>
+
+<script lang=\\"js\\">
+const __sfc_main = {};
+
+__sfc_main.setup = (__props, __ctx) => {
+  const a = ref(1);
+  const b = 1;
+  return Object.assign({
+    a
+  }, {
+    b
+  });
+};
+
+export default __sfc_main;
+</script>
+"
+`;
+
 exports[`transform fixtures test/fixtures/MacrosPure.vue 1`] = `
 "<template>
   <div>{{ msg }}</div>

--- a/test/fixtures/MacrosDefineExpose.vue
+++ b/test/fixtures/MacrosDefineExpose.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>{{a}}</div>
+</template>
+
+<script setup lang="js">
+const a = ref(1);
+const b = 1;
+defineExpose({b});
+</script>


### PR DESCRIPTION
Not exactly the same as Vue 3 since you're not setting _strict_ exports. If we did that, template variables wouldn't work. And this plugin is already adding extra stuff to the Vue 2 instance which wouldn't happen in Vue 3 (because it has to).