### PR TITLE
fix: wrong basename import

### DIFF
--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -1,6 +1,5 @@
-import { resolve } from 'path'
+import { resolve, basename } from 'path'
 import { promises as fs } from 'fs'
-import { basename } from 'path/posix'
 import fg from 'fast-glob'
 
 async function run() {


### PR DESCRIPTION
Sorry, I used an old version of node, I think there is nothing wrong with the current LTS node.