### PR TITLE
fix: declare dependency `@vue/composition-api` and `@vue/runtime-dom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@types/node": "^17.0.8",
     "@types/ws": "^8.2.2",
     "@vue/composition-api": "^1.4.3",
+    "@vue/runtime-dom": "^3.2.26",
     "bumpp": "^7.1.1",
     "eslint": "^8.6.0",
     "fast-glob": "^3.2.10",
@@ -113,7 +114,9 @@
     "vitest": "0.0.120"
   },
   "peerDependencies": {
-    "pug": "^3.0.2"
+    "pug": "^3.0.2",
+    "@vue/composition-api": "^1.4.3",
+    "@vue/runtime-dom": "^3.2.26"
   },
   "peerDependenciesMeta": {
     "pug": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ importers:
       '@vue/compiler-dom': ^3.2.26
       '@vue/composition-api': ^1.4.3
       '@vue/reactivity-transform': ^3.2.26
+      '@vue/runtime-dom': ^3.2.26
       '@vue/shared': ^3.2.26
       bumpp: ^7.1.1
       defu: ^5.0.0
@@ -74,6 +75,7 @@ importers:
       '@types/node': 17.0.8
       '@types/ws': 8.2.2
       '@vue/composition-api': 1.4.3
+      '@vue/runtime-dom': 3.2.27
       bumpp: 7.1.1
       eslint: 8.6.0
       fast-glob: 3.2.10
@@ -2818,36 +2820,36 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/bridge-edge/3.0.0-27366343.1d741cb_0818dea53ce8ce35e46a9f0498c26c7b:
-    resolution: {integrity: sha512-i+2FujRGmDRI3jA2SYGkQhPV7zoesPgOP95whDfC2NtQkZm8i9AV63caiSfODILp+2MTIS/xvGx3MIQxMsiN/g==}
+  /@nuxt/bridge-edge/3.0.0-27373739.0ed2d4a_0818dea53ce8ce35e46a9f0498c26c7b:
+    resolution: {integrity: sha512-+rUOzS4CADVB32rZYzFFRD8xYq6ZSexDbazp/443comFym+RD0e5Pqnv1vdqoVZC31NcuCQegijpOfRPoy6dhQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0}
     hasBin: true
     dependencies:
       '@babel/plugin-transform-typescript': 7.16.8_@babel+core@7.16.7
-      '@nuxt/kit': /@nuxt/kit-edge/3.0.0-27366343.1d741cb
-      '@nuxt/nitro': /@nuxt/nitro-edge/3.0.0-27366343.1d741cb
+      '@nuxt/kit': /@nuxt/kit-edge/3.0.0-27373739.0ed2d4a
+      '@nuxt/nitro': /@nuxt/nitro-edge/3.0.0-27373739.0ed2d4a
       '@nuxt/postcss8': 1.1.3
-      '@nuxt/schema': /@nuxt/schema-edge/3.0.0-27366343.1d741cb
-      '@vitejs/plugin-legacy': 1.6.4_vite@2.7.10
-      '@vue/composition-api': 1.4.3_vue@2.6.14
+      '@nuxt/schema': /@nuxt/schema-edge/3.0.0-27373739.0ed2d4a
+      '@vitejs/plugin-legacy': 1.6.4_vite@2.7.12
+      '@vue/composition-api': 1.4.4_vue@2.6.14
       '@vueuse/head': 0.7.4_vue@2.6.14
       acorn: 8.7.0
       consola: 2.15.3
       cookie-es: 0.5.0
-      defu: 5.0.0
+      defu: 5.0.1
       destr: 1.1.0
       enhanced-resolve: 5.8.3
       estree-walker: 3.0.1
       externality: 0.1.5
       fs-extra: 10.0.0
-      globby: 11.1.0
+      globby: 12.2.0
       h3: 0.3.8
       hash-sum: 2.0.0
       magic-string: 0.25.7
-      mlly: 0.3.17
+      mlly: 0.3.19
       murmurhash-es: 0.1.1
-      node-fetch: 3.1.0
-      nuxi: /nuxi-edge/3.0.0-27366343.1d741cb
+      node-fetch: 3.1.1
+      nuxi: /nuxi-edge/3.0.0-27373739.0ed2d4a
       p-debounce: 4.0.0
       pathe: 0.2.0
       postcss: 8.4.5
@@ -2858,10 +2860,10 @@ packages:
       scule: 0.2.1
       semver: 7.3.5
       ufo: 0.7.9
-      unplugin: 0.3.0_rollup@2.63.0+vite@2.7.10
+      unplugin: 0.3.0_rollup@2.63.0+vite@2.7.12
       unplugin-vue2-script-setup: 'link:'
-      vite: 2.7.10
-      vite-plugin-vue2: 1.9.2_0942e2da5dc468c8f4e6d1df85edc06f
+      vite: 2.7.12
+      vite-plugin-vue2: 1.9.2_12de4b4b1ad5d1d484b4a93dbd918b05
       vue-template-compiler: 2.6.14
     transitivePeerDependencies:
       - '@babel/core'
@@ -2881,7 +2883,7 @@ packages:
   /@nuxt/bridge/0.10.1_0818dea53ce8ce35e46a9f0498c26c7b:
     resolution: {integrity: sha512-KsntjwDDm6de8kWlXCer68B0mj+yF5SNQDlwdKr9cUf0RP9cPh0bkgJYrE5+KOVcq3/V3LUE8qGc5q8Sr7eung==}
     dependencies:
-      '@nuxt/bridge-edge': 3.0.0-27366343.1d741cb_0818dea53ce8ce35e46a9f0498c26c7b
+      '@nuxt/bridge-edge': 3.0.0-27373739.0ed2d4a_0818dea53ce8ce35e46a9f0498c26c7b
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -2936,7 +2938,7 @@ packages:
       connect: 3.7.0
       consola: 2.15.3
       crc: 3.8.0
-      defu: 5.0.0
+      defu: 5.0.1
       destr: 1.1.0
       execa: 5.1.1
       exit: 0.1.2
@@ -2974,7 +2976,7 @@ packages:
     dependencies:
       '@nuxt/utils-edge': 2.16.0-27358576.777a4b7f
       consola: 2.15.3
-      defu: 5.0.0
+      defu: 5.0.1
       destr: 1.1.0
       dotenv: 10.0.0
       lodash: 4.17.21
@@ -3023,7 +3025,7 @@ packages:
       '@nuxt/utils-edge': 2.16.0-27358576.777a4b7f
       chalk: 4.1.2
       consola: 2.15.3
-      defu: 5.0.0
+      defu: 5.0.1
       devalue: 2.0.1
       fs-extra: 10.0.0
       html-minifier: 4.0.0
@@ -3031,19 +3033,19 @@ packages:
       ufo: 0.7.9
     dev: true
 
-  /@nuxt/kit-edge/3.0.0-27366343.1d741cb:
-    resolution: {integrity: sha512-7R9f5xoH+8gLiGSeVyKVpEPwqdbptoJ1X852gbGSMEATLb7Wc0eDVUj4/PTBMSjvYuNm54a0bGO0OG02nXZViw==}
+  /@nuxt/kit-edge/3.0.0-27373739.0ed2d4a:
+    resolution: {integrity: sha512-xQUBq0nOD8gzJ/j6rvuWYGbjyp/+FShXirVbzP4rChX6UE5dMw+0oRBcmQ8ypA1hmpuXhDZHlw1noU0QHg2R9Q==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0}
     dependencies:
-      '@nuxt/schema': /@nuxt/schema-edge/3.0.0-27366343.1d741cb
+      '@nuxt/schema': /@nuxt/schema-edge/3.0.0-27373739.0ed2d4a
       consola: 2.15.3
-      defu: 5.0.0
-      dotenv: 11.0.0
-      globby: 11.1.0
+      defu: 5.0.1
+      dotenv: 14.1.0
+      globby: 12.2.0
       hash-sum: 2.0.0
       jiti: 1.12.9
       lodash.template: 4.5.0
-      mlly: 0.3.17
+      mlly: 0.3.19
       pathe: 0.2.0
       pkg-types: 0.3.2
       rc9: 1.2.0
@@ -3057,44 +3059,44 @@ packages:
     resolution: {integrity: sha512-xpEDAoRu75tLUYCkUJCIvJkWJSuwr8pqomvQ+fkXpSrkxZ/9OzlBFjAbVdOAWTMj4aV/LVQso4vcEdircKeFIQ==}
     dependencies:
       connect: 3.7.0
-      defu: 5.0.0
+      defu: 5.0.1
       get-port-please: 2.2.0
       node-res: 5.0.1
       serve-static: 1.14.2
     dev: true
 
-  /@nuxt/nitro-edge/3.0.0-27366343.1d741cb:
-    resolution: {integrity: sha512-AB+hN0hBpLP9Twad7ovQEcty82TrHkT2wBapPB0XUlg/x5LiqlPLKymfSn9nHsHb2f8ZI/OL01+k7CDG/XLvCQ==}
+  /@nuxt/nitro-edge/3.0.0-27373739.0ed2d4a:
+    resolution: {integrity: sha512-ALqSxK3LmWr1tCKW+bREr5d8Ht5kImeMkQmojmbir5Sqs8wH5eaSrV6/68LZBPwxZUZy1zUZi3mtrOQ78fKU7A==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0}
     dependencies:
       '@cloudflare/kv-asset-handler': 0.2.0
       '@netlify/functions': 0.10.0
       '@nuxt/design': 0.1.5
       '@nuxt/devalue': 2.0.0
-      '@nuxt/kit': /@nuxt/kit-edge/3.0.0-27366343.1d741cb
-      '@rollup/plugin-alias': 3.1.9_rollup@2.63.0
-      '@rollup/plugin-commonjs': 21.0.1_rollup@2.63.0
-      '@rollup/plugin-inject': 4.0.4_rollup@2.63.0
-      '@rollup/plugin-json': 4.1.0_rollup@2.63.0
-      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.63.0
-      '@rollup/plugin-replace': 3.0.1_rollup@2.63.0
-      '@rollup/plugin-virtual': 2.0.3_rollup@2.63.0
-      '@rollup/plugin-wasm': 5.1.2_rollup@2.63.0
+      '@nuxt/kit': /@nuxt/kit-edge/3.0.0-27373739.0ed2d4a
+      '@rollup/plugin-alias': 3.1.9_rollup@2.64.0
+      '@rollup/plugin-commonjs': 21.0.1_rollup@2.64.0
+      '@rollup/plugin-inject': 4.0.4_rollup@2.64.0
+      '@rollup/plugin-json': 4.1.0_rollup@2.64.0
+      '@rollup/plugin-node-resolve': 13.1.3_rollup@2.64.0
+      '@rollup/plugin-replace': 3.0.1_rollup@2.64.0
+      '@rollup/plugin-virtual': 2.0.3_rollup@2.64.0
+      '@rollup/plugin-wasm': 5.1.2_rollup@2.64.0
       '@rollup/pluginutils': 4.1.2
       '@types/jsdom': 16.2.14
-      '@vercel/nft': 0.17.2
+      '@vercel/nft': 0.17.3
       archiver: 5.3.0
       chalk: 5.0.0
       chokidar: 3.5.2
       connect: 3.7.0
       consola: 2.15.3
-      defu: 5.0.0
+      defu: 5.0.1
       destr: 1.1.0
       dot-prop: 6.0.1
       esbuild: 0.14.11
       etag: 1.8.1
       fs-extra: 10.0.0
-      globby: 11.1.0
+      globby: 12.2.0
       gzip-size: 7.0.0
       h3: 0.3.8
       hasha: 5.2.2
@@ -3102,19 +3104,19 @@ packages:
       http-proxy: 1.18.1
       is-primitive: 3.0.1
       jiti: 1.12.9
-      listhen: 0.2.5
+      listhen: 0.2.6
       mime: 3.0.0
-      mlly: 0.3.17
-      node-fetch: 3.1.0
+      mlly: 0.3.19
+      node-fetch: 3.1.1
       ohmyfetch: 0.4.14
       ora: 6.0.1
       p-debounce: 4.0.0
       pathe: 0.2.0
       pkg-types: 0.3.2
       pretty-bytes: 5.6.0
-      rollup: 2.63.0
-      rollup-plugin-terser: 7.0.2_rollup@2.63.0
-      rollup-plugin-visualizer: 5.5.2_rollup@2.63.0
+      rollup: 2.64.0
+      rollup-plugin-terser: 7.0.2_rollup@2.64.0
+      rollup-plugin-visualizer: 5.5.4_rollup@2.64.0
       serve-placeholder: 1.2.4
       serve-static: 1.14.2
       std-env: 3.0.1
@@ -3156,12 +3158,12 @@ packages:
       - webpack
     dev: true
 
-  /@nuxt/schema-edge/3.0.0-27366343.1d741cb:
-    resolution: {integrity: sha512-u3EFLXiisctQlKFLEsuVYxdZroO7FnrMZV1uAOHUbgyX4/0oakhCeFbKko754HaD4wgawFHIPZ2YDJGi1eTO5g==}
+  /@nuxt/schema-edge/3.0.0-27373739.0ed2d4a:
+    resolution: {integrity: sha512-eMID8ninnb8BwN9b+YpvPbO8tEOrBrvy+2n8wbQe10JhVvf5lLZ+zpGIvlMQbLoFuEEsd444i4m7S5svSr5dTQ==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0}
     dependencies:
       create-require: 1.1.1
-      defu: 5.0.0
+      defu: 5.0.1
       jiti: 1.12.9
       pathe: 0.2.0
       scule: 0.2.1
@@ -3200,7 +3202,7 @@ packages:
       ci-info: 3.3.0
       consola: 2.15.3
       create-require: 1.1.1
-      defu: 5.0.0
+      defu: 5.0.1
       destr: 1.1.0
       dotenv: 9.0.2
       fs-extra: 8.1.0
@@ -3208,7 +3210,7 @@ packages:
       inquirer: 7.3.3
       is-docker: 2.2.1
       jiti: 1.12.9
-      nanoid: 3.1.30
+      nanoid: 3.2.0
       node-fetch: 2.6.6
       parse-git-config: 3.0.0
       rc9: 1.2.0
@@ -3253,7 +3255,7 @@ packages:
       '@nuxt/devalue': 2.0.0
       '@nuxt/utils-edge': 2.16.0-27358576.777a4b7f
       consola: 2.15.3
-      defu: 5.0.0
+      defu: 5.0.1
       fs-extra: 10.0.0
       lodash: 4.17.21
       lru-cache: 5.1.1
@@ -3343,6 +3345,16 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /@rollup/plugin-alias/3.1.9_rollup@2.64.0:
+    resolution: {integrity: sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==}
+    engines: {node: '>=8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      rollup: 2.64.0
+      slash: 3.0.0
+    dev: true
+
   /@rollup/plugin-commonjs/21.0.1_rollup@2.63.0:
     resolution: {integrity: sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==}
     engines: {node: '>= 8.0.0'}
@@ -3359,15 +3371,31 @@ packages:
       rollup: 2.63.0
     dev: true
 
-  /@rollup/plugin-inject/4.0.4_rollup@2.63.0:
+  /@rollup/plugin-commonjs/21.0.1_rollup@2.64.0:
+    resolution: {integrity: sha512-EA+g22lbNJ8p5kuZJUYyhhDK7WgJckW5g4pNN7n4mAFUM96VuwUnNT3xr2Db2iCZPI1pJPbGyfT5mS9T1dHfMg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^2.38.3
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.64.0
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 7.2.0
+      is-reference: 1.2.1
+      magic-string: 0.25.7
+      resolve: 1.20.0
+      rollup: 2.64.0
+    dev: true
+
+  /@rollup/plugin-inject/4.0.4_rollup@2.64.0:
     resolution: {integrity: sha512-4pbcU4J/nS+zuHk+c+OL3WtmEQhqxlZ9uqfjQMQDOHOPld7PsCd8k5LWs8h5wjwJN7MgnAn768F2sDxEP4eNFQ==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.63.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.64.0
       estree-walker: 2.0.2
       magic-string: 0.25.7
-      rollup: 2.63.0
+      rollup: 2.64.0
     dev: true
 
   /@rollup/plugin-json/4.1.0_rollup@2.63.0:
@@ -3377,6 +3405,15 @@ packages:
     dependencies:
       '@rollup/pluginutils': 3.1.0_rollup@2.63.0
       rollup: 2.63.0
+    dev: true
+
+  /@rollup/plugin-json/4.1.0_rollup@2.64.0:
+    resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.64.0
+      rollup: 2.64.0
     dev: true
 
   /@rollup/plugin-node-resolve/13.1.3_rollup@2.63.0:
@@ -3394,31 +3431,46 @@ packages:
       rollup: 2.63.0
     dev: true
 
-  /@rollup/plugin-replace/3.0.1_rollup@2.63.0:
+  /@rollup/plugin-node-resolve/13.1.3_rollup@2.64.0:
+    resolution: {integrity: sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      rollup: ^2.42.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.64.0
+      '@types/resolve': 1.17.1
+      builtin-modules: 3.2.0
+      deepmerge: 4.2.2
+      is-module: 1.0.0
+      resolve: 1.20.0
+      rollup: 2.64.0
+    dev: true
+
+  /@rollup/plugin-replace/3.0.1_rollup@2.64.0:
     resolution: {integrity: sha512-989J5oRzf3mm0pO/0djTijdfEh9U3n63BIXN5X7T4U9BP+fN4oxQ6DvDuBvFaHA6scaHQRclqmKQEkBhB7k7Hg==}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.63.0
+      '@rollup/pluginutils': 3.1.0_rollup@2.64.0
       magic-string: 0.25.7
-      rollup: 2.63.0
+      rollup: 2.64.0
     dev: true
 
-  /@rollup/plugin-virtual/2.0.3_rollup@2.63.0:
+  /@rollup/plugin-virtual/2.0.3_rollup@2.64.0:
     resolution: {integrity: sha512-pw6ziJcyjZtntQ//bkad9qXaBx665SgEL8C8KI5wO8G5iU5MPxvdWrQyVaAvjojGm9tJoS8M9Z/EEepbqieYmw==}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0
     dependencies:
-      rollup: 2.63.0
+      rollup: 2.64.0
     dev: true
 
-  /@rollup/plugin-wasm/5.1.2_rollup@2.63.0:
+  /@rollup/plugin-wasm/5.1.2_rollup@2.64.0:
     resolution: {integrity: sha512-eiOuMHBNY0EGTq3LCebg4IQ6/SOvKjmGetzqKajJWcbDQkrQZvHihZKKnBJYY7NuuvjNqCLdEViYr5aAZms63g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      rollup: 2.63.0
+      rollup: 2.64.0
     dev: true
 
   /@rollup/pluginutils/3.1.0_rollup@2.63.0:
@@ -3431,6 +3483,18 @@ packages:
       estree-walker: 1.0.1
       picomatch: 2.3.0
       rollup: 2.63.0
+    dev: true
+
+  /@rollup/pluginutils/3.1.0_rollup@2.64.0:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.0
+      rollup: 2.64.0
     dev: true
 
   /@rollup/pluginutils/4.1.2:
@@ -3839,8 +3903,8 @@ packages:
       eslint-visitor-keys: 3.1.0
     dev: true
 
-  /@vercel/nft/0.17.2:
-    resolution: {integrity: sha512-1ueYh62H/DmUc3PWV/HEk1x6J1c/KZq9zeNXhixn/C4lX3XOsouutUVpKhTseoDKTGlT81hx96W4TjIwpDiIAQ==}
+  /@vercel/nft/0.17.3:
+    resolution: {integrity: sha512-fdGzXF8dVrHliAzk4p2TOfG78K7MgWleDZ0+ztDQe6TdBw31c3S6Fvg6rdcV8g4Y20HTFtPzKua3uj3PGRagZg==}
     hasBin: true
     dependencies:
       '@mapbox/node-pre-gyp': 1.0.8
@@ -3850,7 +3914,6 @@ packages:
       glob: 7.2.0
       graceful-fs: 4.2.9
       micromatch: 4.0.4
-      mkdirp: 0.5.5
       node-gyp-build: 4.3.0
       node-pre-gyp: 0.13.0
       resolve-from: 5.0.0
@@ -3859,7 +3922,7 @@ packages:
       - supports-color
     dev: true
 
-  /@vitejs/plugin-legacy/1.6.4_vite@2.7.10:
+  /@vitejs/plugin-legacy/1.6.4_vite@2.7.12:
     resolution: {integrity: sha512-geH2F3hTRN++E4n9NZ0JFumxIWUKqW4FA9PAgM7Q6RvUOUUYW4tlURhEmCBYfZSN24H/yX3mEolX+wFVErsAYQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
@@ -3870,7 +3933,7 @@ packages:
       magic-string: 0.25.7
       regenerator-runtime: 0.13.9
       systemjs: 6.11.0
-      vite: 2.7.10
+      vite: 2.7.12
     dev: true
 
   /@vue/babel-helper-vue-jsx-merge-props/1.2.1:
@@ -4337,6 +4400,16 @@ packages:
     dependencies:
       tslib: 2.3.1
       vue: 2.6.14
+    dev: false
+
+  /@vue/composition-api/1.4.4_vue@2.6.14:
+    resolution: {integrity: sha512-0AMpkSy28NG1BUqTPXLfQzJUnjSp+qUa4jaG7A2FBRSKHJOl1g10/xvNb44+OW5Jg9f79zKOb7PYhFhJG2vLyQ==}
+    peerDependencies:
+      vue: '>= 2.5 < 3'
+    dependencies:
+      tslib: 2.3.1
+      vue: 2.6.14
+    dev: true
 
   /@vue/preload-webpack-plugin/1.1.2_502c618fc8a7d35df07e93275324a2d0:
     resolution: {integrity: sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==}
@@ -4359,9 +4432,34 @@ packages:
       magic-string: 0.25.7
     dev: false
 
+  /@vue/reactivity/3.2.27:
+    resolution: {integrity: sha512-QPfIQEJidRGIu/mPexhcB4csp1LEg2Nr+/QE72MnXs/OYDtFErhC9FxIyymkxp/xvAgL5wsnSOuDD6zWF42vRQ==}
+    dependencies:
+      '@vue/shared': 3.2.27
+    dev: true
+
+  /@vue/runtime-core/3.2.27:
+    resolution: {integrity: sha512-NJrjuViHJyrT4bwIocbE4XDaDlA1Pj61pQlneZZdFEvgdMLlhzCCiJ4WZnWcohYQeisUAZjEFKK8GjQieDPFbw==}
+    dependencies:
+      '@vue/reactivity': 3.2.27
+      '@vue/shared': 3.2.27
+    dev: true
+
+  /@vue/runtime-dom/3.2.27:
+    resolution: {integrity: sha512-tlnKkvBSkV7MPUp/wRFsYcv67U1rUeZTPfpPzq5Kpmw5NNGkY6J075fFBH2k0MNxDucXS+qfStNrxAyGTUMkSA==}
+    dependencies:
+      '@vue/runtime-core': 3.2.27
+      '@vue/shared': 3.2.27
+      csstype: 2.6.19
+    dev: true
+
   /@vue/shared/3.2.26:
     resolution: {integrity: sha512-vPV6Cq+NIWbH5pZu+V+2QHE9y1qfuTq49uNWw4f7FDEeZaDU2H2cx5jcUZOAKW7qTrUS4k6qZPbMy1x4N96nbA==}
     dev: false
+
+  /@vue/shared/3.2.27:
+    resolution: {integrity: sha512-rpAn9k6O08Lvo7ekBIAnkOukX/4EsEQLPrRJBKhIEasMsOI5eX0f6mq1sDUSY7cgAqWw2d7QtP74CWxdXoyKxA==}
+    dev: true
 
   /@vue/web-component-wrapper/1.3.0:
     resolution: {integrity: sha512-Iu8Tbg3f+emIIMmI2ycSI8QcEuAUgPTgHwesDU1eKMLE4YC/c/sFbGc70QgMq31ijRftV0R7vCm9co6rldCeOA==}
@@ -4865,6 +4963,11 @@ packages:
   /array-union/2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /array-union/3.0.1:
+    resolution: {integrity: sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==}
+    engines: {node: '>=12'}
     dev: true
 
   /array-uniq/1.0.3:
@@ -6281,6 +6384,15 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
+  /clipboardy/3.0.0:
+    resolution: {integrity: sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      arch: 2.2.0
+      execa: 5.1.1
+      is-wsl: 2.2.0
+    dev: true
+
   /cliui/5.0.0:
     resolution: {integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==}
     dependencies:
@@ -7032,6 +7144,10 @@ packages:
       css-tree: 1.1.3
     dev: true
 
+  /csstype/2.6.19:
+    resolution: {integrity: sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ==}
+    dev: true
+
   /cuint/0.2.2:
     resolution: {integrity: sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=}
     dev: true
@@ -7216,6 +7332,11 @@ packages:
 
   /defu/5.0.0:
     resolution: {integrity: sha512-VHg73EDeRXlu7oYWRmmrNp/nl7QkdXUxkQQKig0Zk8daNmm84AbGoC8Be6/VVLJEKxn12hR0UBmz8O+xQiAPKQ==}
+    dev: false
+
+  /defu/5.0.1:
+    resolution: {integrity: sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==}
+    dev: true
 
   /del/4.1.1:
     resolution: {integrity: sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==}
@@ -7434,8 +7555,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /dotenv/11.0.0:
-    resolution: {integrity: sha512-Fp/b504Y5W+e+FpCxTFMUZ7ZEQkQYF0rx+KZtmwixJxGQbLHrhCwo3FjZgNC8vIfrSi29PABNbMoCGD9YoiXbQ==}
+  /dotenv/14.1.0:
+    resolution: {integrity: sha512-h8V+Yfa8m0YSjf3Rgbno51cxWldb4PEixIJVL55VmW7uAfeLQKiaPrEUiBps+ARK9MeqjJgTf269OMmu6lOODQ==}
     engines: {node: '>=12'}
     dev: true
 
@@ -8519,7 +8640,7 @@ packages:
     dependencies:
       allowlist: 0.1.1
       enhanced-resolve: 5.8.3
-      mlly: 0.3.17
+      mlly: 0.3.19
       pathe: 0.2.0
       ufo: 0.7.9
     dev: true
@@ -9210,6 +9331,18 @@ packages:
       ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
+    dev: true
+
+  /globby/12.2.0:
+    resolution: {integrity: sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      array-union: 3.0.1
+      dir-glob: 3.0.1
+      fast-glob: 3.2.10
+      ignore: 5.2.0
+      merge2: 1.4.1
+      slash: 4.0.0
     dev: true
 
   /globby/6.1.0:
@@ -10644,16 +10777,16 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
-  /listhen/0.2.5:
-    resolution: {integrity: sha512-7stTOFjeQHVkDqpPl0AtGdzXNu1XN5sE2Pi4mudeZ597c100OKvUpmPuv3MKemDScIWqmIbeUOeP3PBo0w49XQ==}
+  /listhen/0.2.6:
+    resolution: {integrity: sha512-/xpN3784qRxyxS9wjiVB0vWE9NqoT+5nvOw5KBRB4tXtsjp7y83CJe6Gi/WtoTkkDqXwhSNStqaJ3r/7J0ZCDA==}
     dependencies:
-      clipboardy: 2.3.0
-      colorette: 1.3.0
-      defu: 5.0.0
+      clipboardy: 3.0.0
+      colorette: 2.0.16
+      defu: 5.0.1
       get-port-please: 2.2.0
       http-shutdown: 1.2.2
       open: 8.4.0
-      selfsigned: 1.10.11
+      selfsigned: 2.0.0
     dev: true
 
   /loader-runner/2.4.0:
@@ -11188,8 +11321,8 @@ packages:
     hasBin: true
     dev: true
 
-  /mlly/0.3.17:
-    resolution: {integrity: sha512-C3v8eHB9KqmS1ewOB5DUgljX13C3xuoaXZd5bOLtwpxk9pBZhA+wyVgYXPuP4aukQ9bKYWjy+YQVC+DmniIsgA==}
+  /mlly/0.3.19:
+    resolution: {integrity: sha512-zMq5n3cOf4fOzA4WoeulxagbAgMChdev3MgP6K51k7M0u2whTXxupfIY4VVzws4vxkiWhwH1rVQcsw7zDGfRhA==}
     dev: true
 
   /move-concurrently/1.0.1:
@@ -11273,6 +11406,12 @@ packages:
     hasBin: true
     dev: true
 
+  /nanoid/3.2.0:
+    resolution: {integrity: sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /nanomatch/1.2.13:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
     engines: {node: '>=0.10.0'}
@@ -11337,8 +11476,8 @@ packages:
       whatwg-url: 5.0.0
     dev: true
 
-  /node-fetch/3.1.0:
-    resolution: {integrity: sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==}
+  /node-fetch/3.1.1:
+    resolution: {integrity: sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       data-uri-to-buffer: 4.0.0
@@ -11349,6 +11488,11 @@ packages:
   /node-forge/0.10.0:
     resolution: {integrity: sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==}
     engines: {node: '>= 6.0.0'}
+    dev: true
+
+  /node-forge/1.2.1:
+    resolution: {integrity: sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==}
+    engines: {node: '>= 6.13.0'}
     dev: true
 
   /node-gyp-build/4.3.0:
@@ -11577,8 +11721,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /nuxi-edge/3.0.0-27366343.1d741cb:
-    resolution: {integrity: sha512-jiO5mK8SQp6DoELJKLg3yK9ppP32Q2707JaHOCOS2h1Vu6x1cZS6ohMB8/Zh2GRIX22BmM2TQOSQNR7ba9LRFg==}
+  /nuxi-edge/3.0.0-27373739.0ed2d4a:
+    resolution: {integrity: sha512-iG8N8xnfQbnwnqAV3TUEDwsik1KXCCUnGoC4nNH+91O6O42mXhJy3VGvm+I5/6KTtsFXDI1slFI/y6sgabqn1A==}
     engines: {node: ^14.16.0 || ^16.11.0 || ^17.0.0}
     hasBin: true
     optionalDependencies:
@@ -11725,7 +11869,7 @@ packages:
     resolution: {integrity: sha512-kWllHM3DVJdwB4BpEoHhe+JUviDArit3ZQyVI2X2sxhCYZXlGHAABrsjJ07bac0RG3tae08BnKWy4eRMPKMh4w==}
     dependencies:
       destr: 1.1.0
-      node-fetch: 3.1.0
+      node-fetch: 3.1.1
       ufo: 0.7.9
       undici: 4.12.1
     dev: true
@@ -11767,14 +11911,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       is-wsl: 1.1.0
-    dev: true
-
-  /open/7.4.2:
-    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
-    engines: {node: '>=8'}
-    dependencies:
-      is-docker: 2.2.1
-      is-wsl: 2.2.0
     dev: true
 
   /open/8.4.0:
@@ -12240,7 +12376,7 @@ packages:
     resolution: {integrity: sha512-eBYzX/7NYsQEOR2alWY4rnQB49G62oHzFpoi9Som56aUr8vB8UGcmcIia9v8fpBeuhH3Ltentuk2OGpp4IQV3Q==}
     dependencies:
       jsonc-parser: 3.0.0
-      mlly: 0.3.17
+      mlly: 0.3.19
       pathe: 0.2.0
     dev: true
 
@@ -14064,14 +14200,14 @@ packages:
       '@babel/code-frame': 7.16.7
     dev: true
 
-  /rollup-plugin-terser/7.0.2_rollup@2.63.0:
+  /rollup-plugin-terser/7.0.2_rollup@2.64.0:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
       '@babel/code-frame': 7.16.7
       jest-worker: 26.6.2
-      rollup: 2.63.0
+      rollup: 2.64.0
       serialize-javascript: 4.0.0
       terser: 5.7.1
     dev: true
@@ -14096,18 +14232,18 @@ packages:
       - ts-toolbelt
     dev: true
 
-  /rollup-plugin-visualizer/5.5.2_rollup@2.63.0:
-    resolution: {integrity: sha512-sh+P9KhuWTzeStyRA5yNZpoEFGuj5Ph34JLMa9+muhU8CneFf9L0XE4fmAwAojJLWp//uLUEyytBPSCdZEg5AA==}
-    engines: {node: '>=10.16'}
+  /rollup-plugin-visualizer/5.5.4_rollup@2.64.0:
+    resolution: {integrity: sha512-CJQFUuZ75S1daGEkk62UH7lL6UFCoP86Sn/iz4gXBdamdwFeD5nPGCHHXfXCrly/wNgQOYTH7cdcxk4+OG3Xjw==}
+    engines: {node: '>=12'}
     hasBin: true
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      nanoid: 3.1.30
-      open: 7.4.2
-      rollup: 2.63.0
+      nanoid: 3.2.0
+      open: 8.4.0
+      rollup: 2.64.0
       source-map: 0.7.3
-      yargs: 16.2.0
+      yargs: 17.3.1
     dev: true
 
   /rollup-pluginutils/2.8.2:
@@ -14126,6 +14262,14 @@ packages:
 
   /rollup/2.63.0:
     resolution: {integrity: sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup/2.64.0:
+    resolution: {integrity: sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==}
     engines: {node: '>=10.0.0'}
     hasBin: true
     optionalDependencies:
@@ -14244,6 +14388,13 @@ packages:
       node-forge: 0.10.0
     dev: true
 
+  /selfsigned/2.0.0:
+    resolution: {integrity: sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      node-forge: 1.2.1
+    dev: true
+
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
@@ -14344,7 +14495,7 @@ packages:
   /serve-placeholder/1.2.4:
     resolution: {integrity: sha512-jWD9cZXLcr4vHTTL5KEPIUBUYyOWN/z6v/tn0l6XxFhi9iqV3Fc5Y1aFeduUyz+cx8sALzGCUczkPfeOlrq9jg==}
     dependencies:
-      defu: 5.0.0
+      defu: 5.0.1
     dev: true
 
   /serve-static/1.14.1:
@@ -14494,6 +14645,11 @@ packages:
   /slash/3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+    dev: true
+
+  /slash/4.0.0:
+    resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
+    engines: {node: '>=12'}
     dev: true
 
   /slice-ansi/4.0.0:
@@ -15540,11 +15696,11 @@ packages:
     resolution: {integrity: sha512-S1H/L2w3uZ7uD+hYpC+UTPlMhjKMn7SBExT6PNRzXRhMc2Vy+KPcnR7ktrzGWu+8r6hs/Vi/7Sw7cXP72L03oA==}
     dependencies:
       buffer: 6.0.3
-      defu: 5.0.0
+      defu: 5.0.1
       events: 3.3.0
       inherits: 2.0.4
       mime: 2.5.2
-      node-fetch: 3.1.0
+      node-fetch: 3.1.1
       process: 0.11.10
       upath: 2.0.1
       util: 0.12.4
@@ -15642,6 +15798,29 @@ packages:
       rollup: 2.63.0
       vite: 2.7.10
       webpack-virtual-modules: 0.4.3
+    dev: false
+
+  /unplugin/0.3.0_rollup@2.63.0+vite@2.7.12:
+    resolution: {integrity: sha512-9yLlOo+XC4NdIRgpkDSHOAHkQDq2x4mbuVNO/eKVa3C8WTn5wWGfzEFfRJFL8euqnX3Gf7hEur0AhXxy+WSwkg==}
+    peerDependencies:
+      esbuild: '>=0.13'
+      rollup: ^2.50.0
+      vite: ^2.3.0
+      webpack: 4 || 5
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+    dependencies:
+      rollup: 2.63.0
+      vite: 2.7.12
+      webpack-virtual-modules: 0.4.3
+    dev: true
 
   /unquote/1.1.1:
     resolution: {integrity: sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=}
@@ -15663,7 +15842,7 @@ packages:
       destr: 1.1.0
       h3: 0.3.8
       ioredis: 4.28.3
-      listhen: 0.2.5
+      listhen: 0.2.6
       mri: 1.2.0
       ohmyfetch: 0.4.14
       ufo: 0.7.9
@@ -15903,6 +16082,39 @@ packages:
       - supports-color
     dev: true
 
+  /vite-plugin-vue2/1.9.2_12de4b4b1ad5d1d484b4a93dbd918b05:
+    resolution: {integrity: sha512-y6a7tlqXe2OtwD0N7mNvlrZaQu2aeqGXzwk+MjEacUsOd70t/K1Qno1eNqH3+7evC/Klbou9VdYc/Pu0Sp7PfA==}
+    peerDependencies:
+      vite: ^2.0.0-beta.23
+      vue-template-compiler: ^2.2.0
+    dependencies:
+      '@babel/core': 7.16.0
+      '@babel/parser': 7.16.4
+      '@babel/plugin-proposal-class-properties': 7.14.5_@babel+core@7.16.0
+      '@babel/plugin-proposal-decorators': 7.16.0_@babel+core@7.16.0
+      '@babel/plugin-transform-typescript': 7.16.1_@babel+core@7.16.0
+      '@rollup/pluginutils': 4.1.2
+      '@vue/babel-helper-vue-jsx-merge-props': 1.2.1
+      '@vue/babel-preset-jsx': 1.2.4_@babel+core@7.16.0
+      '@vue/component-compiler-utils': 3.2.2
+      babel-preset-env: 1.7.0
+      consolidate: 0.16.0
+      debug: 4.3.3
+      fs-extra: 9.1.0
+      hash-sum: 2.0.0
+      magic-string: 0.25.7
+      prettier: 2.4.1
+      querystring: 0.2.1
+      rollup: 2.63.0
+      slash: 3.0.0
+      source-map: 0.7.3
+      vite: 2.7.12
+      vue-template-compiler: 2.6.14
+      vue-template-es2015-compiler: 1.9.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vite/2.7.10:
     resolution: {integrity: sha512-KEY96ntXUid1/xJihJbgmLZx7QSC2D4Tui0FdS0Old5OokYzFclcofhtxtjDdGOk/fFpPbHv9yw88+rB93Tb8w==}
     engines: {node: '>=12.2.0'}
@@ -15923,6 +16135,30 @@ packages:
       postcss: 8.4.5
       resolve: 1.20.0
       rollup: 2.60.2
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite/2.7.12:
+    resolution: {integrity: sha512-KvPYToRQWhRfBeVkyhkZ5hASuHQkqZUUdUcE3xyYtq5oYEPIJ0h9LWiWTO6v990glmSac2cEPeYeXzpX5Z6qKQ==}
+    engines: {node: '>=12.2.0'}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+    dependencies:
+      esbuild: 0.13.15
+      postcss: 8.4.5
+      resolve: 1.20.0
+      rollup: 2.64.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -16616,6 +16852,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /yargs-parser/21.0.0:
+    resolution: {integrity: sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==}
+    engines: {node: '>=12'}
+    dev: true
+
   /yargs/13.3.2:
     resolution: {integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==}
     dependencies:
@@ -16642,6 +16883,19 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+    dev: true
+
+  /yargs/17.3.1:
+    resolution: {integrity: sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.0.0
     dev: true
 
   /yocto-queue/0.1.0:


### PR DESCRIPTION
**What's the problem this PR addresses?**

`unplugin-vue2-script-setup` tries to [export types from `@vue/composition-api` and `@vue/runtime-dom`](https://github.com/antfu/unplugin-vue2-script-setup/blob/1ded5c7c21ffa99f797789c5bfda2de4b9083ac2/shims.d.ts) but declares neither of them as dependencies so they both fail to resolve under strict dependency environments.

**How did you fix it?**

Declare both as peer dependencies