### PR TITLE
feat: Support @vue/vue2-jest

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -1,10 +1,23 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { transform } = require('./dist/index')
 
+function requireVueJest() {
+  const names = ['@vue/vue2-jest', 'vue-jest']
+  for (const name of names) {
+    try {
+      return require(name)
+    }
+    catch (e) {
+      // Try next module
+    }
+  }
+  throw new Error(`Cannot find a Jest transformer for Vue SFC, you should install one of these packages: ${names.join(', ')}`)
+}
+
 module.exports = {
   process(source, filename, ...args) {
     const transformed = transform(source, filename)
     const code = transformed ? transformed.code : source
-    return require('vue-jest').process.call(this, code, filename, ...args)
+    return requireVueJest().process.call(this, code, filename, ...args)
   },
 }


### PR DESCRIPTION
Users of Jest 27 currently need to redefine their own Jest transformer.
This contribution tries to load either `vue-jest` or `@vue/vue2-jest` so that it is not needed anymore.