### PR TITLE
 fix: types in root dir

### DIFF
--- a/esbuild.d.ts
+++ b/esbuild.d.ts
@@ -1,2 +1,1 @@
-import './shims'
 export { default } from './dist/esbuild'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,2 @@
-import './shims'
+export * from './dist/index'
 export { default } from './dist/index'

--- a/nuxt.d.ts
+++ b/nuxt.d.ts
@@ -1,2 +1,1 @@
-import './shims'
 export { default } from './dist/nuxt'

--- a/rollup.d.ts
+++ b/rollup.d.ts
@@ -1,2 +1,1 @@
-import './shims'
 export { default } from './dist/rollup'

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,2 +1,1 @@
-import './shims'
-export { default } from './dist/types'
+export * from './dist/types'

--- a/vite.d.ts
+++ b/vite.d.ts
@@ -1,2 +1,1 @@
-import './shims'
 export { default } from './dist/vite'

--- a/webpack.d.ts
+++ b/webpack.d.ts
@@ -1,2 +1,1 @@
-import './shims'
 export { default } from './dist/webpack'


### PR DESCRIPTION

since ts 4.5, typescript will read `exports` field in package.json

```json
{
  "exports": {
    ".": {
      "require": "./dist/index.js",
      "import": "./dist/index.mjs",
      "types": "./index.d.ts"
    },
    ...
  },
  ...
}
```

So we should keep type in root dir same as types in dist dir.