### PR TITLE
feat: add lib output

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,11 @@
       "require": "./dist/webpack.js",
       "import": "./dist/webpack.mjs",
       "types": "./webpack.d.ts"
+    },
+    "./lib": {
+      "require": "./dist/lib.js",
+      "import": "./dist/lib.mjs",
+      "types": "./lib.d.ts"
     }
   },
   "main": "dist/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,6 +14,7 @@ const entries = [
   'src/rollup.ts',
   'src/esbuild.ts',
   'src/nuxt.ts',
+  'src/lib.ts',
 ]
 
 const dtsEntries = [

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,1 @@
+export * from './core'


### PR DESCRIPTION
This PR added a new entry called 'lib'.

Current 'index' has many node-only dependencies and we cannot port it into browser easily.