### PR TITLE
fix: strict version range to 2.6.x

### DIFF
--- a/examples/vue-cli/package.json
+++ b/examples/vue-cli/package.json
@@ -18,7 +18,7 @@
     "@vue/cli-service": "^5.0.4",
     "typescript": "^4.7.4",
     "unplugin-vue2-script-setup": "workspace:*",
-    "vue-template-compiler": "^2.6.14",
+    "vue-template-compiler": "~2.6.14",
     "vue-tsc": "^0.38.1"
   }
 }

--- a/examples/vue-cli/package.json
+++ b/examples/vue-cli/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@vue/composition-api": "^1.6.2",
     "core-js": "^3.22.7",
-    "vue": "^2.6.14"
+    "vue": "~2.6.14"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^5.0.4",


### PR DESCRIPTION
such like:
```vue
<script setup lang="ts">
const count = ref(0)
</script>
<template>
  <span>{{ count }}</span>
</template>
```
console will throw error:
```bash
 The setup binding property "count" is already declared.
```
and this will appears to dom:
{ "value": 0 }